### PR TITLE
Transform to profile with NVTX markers

### DIFF
--- a/scratchpad/profile_transform.py
+++ b/scratchpad/profile_transform.py
@@ -1,0 +1,131 @@
+from thunder.core.trace import TraceCtx as Trace, from_trace, TraceProvenance
+import thunder.core.prims as prims
+from thunder.core.prims import PrimIDs
+from thunder.extend import OperatorExecutor
+import time
+import torch
+import thunder
+
+
+class Timer:
+    def __init__(self):
+        self.start_time_ns = None
+        self.end_time_ns = None
+
+    def __enter__(self):
+        self.start_time_ns = time.time_ns()
+        return self
+
+    def __exit__(self, *args):
+        self.end_time_ns = time.time_ns()
+
+    def get_elapsed_time_in_ms(self):
+        elapsed_time_ns = self.end_time_ns - self.start_time_ns
+        return elapsed_time_ns // 1000000
+
+
+nvtx_profiler_ex = OperatorExecutor("nvtx_profiler_ex")
+
+
+# Symbols for profiling.
+def nvtx_push_impl(msg):
+    torch.cuda.nvtx.range_push(msg)
+
+
+def nvtx_pop_impl():
+    torch.cuda.nvtx.range_pop()
+
+
+def profile_start_impl():
+    torch.cuda.cudart().cudaProfilerStart()
+
+
+def profile_stop_impl():
+    torch.cuda.synchronize()
+    torch.cuda.cudart().cudaProfilerStop()
+
+
+tags = (prims.OpTags.DONT_DCE,)
+nvtx_push = nvtx_profiler_ex.register_operator("nvtx_range_push", meta=lambda msg: None, fn=nvtx_push_impl, tags=tags)
+nvtx_pop = nvtx_profiler_ex.register_operator("nvtx_range_pop", meta=lambda: None, fn=nvtx_pop_impl, tags=tags)
+cuda_profiler_start = nvtx_profiler_ex.register_operator(
+    "cuda_profiler_start", meta=lambda: None, fn=profile_start_impl, tags=tags
+)
+cuda_profiler_stop = nvtx_profiler_ex.register_operator(
+    "cuda_profiler_stop", meta=lambda: None, fn=profile_stop_impl, tags=tags
+)
+
+NON_COMPUTATION_PRIMS = (
+    PrimIDs.ASSERT_TENSOR_METADATA,
+    PrimIDs.CHECK_TENSOR_SHAPE_AND_METADATA,
+    PrimIDs.CHECK_NONE,
+    PrimIDs.CHECK_EMPTY,
+    PrimIDs.CHECK_LITERAL_LIKE,
+    PrimIDs.CHECK_TYPE,
+    PrimIDs.CHECK_INSTANCE,
+    PrimIDs.CHECK_NUMBER_TYPE_AND_VALUE,
+    PrimIDs.CHECK_BOOL_CONVERSION,
+    PrimIDs.CHECK_STRING_VALUE,
+    PrimIDs.CHECK_LEN,
+    PrimIDs.ASSERT_COMPARE,
+    PrimIDs.PYTHON_VARS,
+    PrimIDs.UNPACK_FUNCTION_OBJ,
+    PrimIDs.UNPACK_CACHE_INFO,
+    PrimIDs.UNPACK_ATTR,
+    PrimIDs.UNPACK_GETITEM,
+    PrimIDs.UNPACK_EMPTY_DICT,
+    PrimIDs.UNPACK_ITER,
+    PrimIDs.UNPACK_NEXT,
+    PrimIDs.UNPACK_KEY,
+    PrimIDs.UNPACK_SEQUENCE,
+    PrimIDs.UNPACK_TRIVIAL,
+    PrimIDs.UNPACK_TUPLE,
+    PrimIDs.UNPACK_LIST,
+    PrimIDs.UNPACK_DICT_KEY,
+    PrimIDs.CONSTRUCT_TUPLE,
+    PrimIDs.PACK_SETITEM,
+    # TODO: UNPACK_SET
+    # Utility prims
+    PrimIDs.COMMENT,
+    PrimIDs.DEL,
+    PrimIDs.PRINT,
+)
+
+
+def nvtx_profile_transform(trace: Trace, **kwargs) -> Trace:
+    with Timer() as timer:
+        profile_trace = from_trace(trace)
+
+        # Start profiling
+        profile_trace.bound_symbols.append(cuda_profiler_start.bind(output=None))
+        for bound_symbol in trace.bound_symbols:
+            # Synchronize and stop profiling at return.
+            if PrimIDs.RETURN == bound_symbol.sym.id:
+                profile_trace.bound_symbols.append(cuda_profiler_stop.bind(output=None))
+                profile_trace.bound_symbols.append(bound_symbol)
+                break
+
+            if bound_symbol.sym.id in NON_COMPUTATION_PRIMS:
+                # Just append the symbol.
+                profile_trace.bound_symbols.append(bound_symbol)
+                continue
+
+            profile_trace.bound_symbols.append(nvtx_push.bind(f"{bound_symbol.python(indent=0)}", output=None))
+            profile_trace.bound_symbols.append(bound_symbol)
+            profile_trace.bound_symbols.append(nvtx_pop.bind(output=None))
+
+    profile_trace.set_provenance(
+        TraceProvenance(f"Profile Transform (took {timer.get_elapsed_time_in_ms()} milliseconds)")
+    )
+    return profile_trace
+
+
+def profile_with_nvtx(compiled_model):
+    def _fn(*args, **kwargs):
+        exec_trace = thunder.last_traces(compiled_model)[-1]
+        profile_trace = nvtx_profile_transform(exec_trace)
+        cache_rec, inputs, _ = thunder.compile_data(compiled_model).get_computation_and_inputs(*args, **kwargs)
+        profile_callable = profile_trace.python_callable()
+        return profile_callable(*inputs)
+
+    return _fn

--- a/scratchpad/test_profiler.py
+++ b/scratchpad/test_profiler.py
@@ -1,0 +1,48 @@
+import torch
+import thunder
+
+dim = 4096
+
+
+class Model(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = torch.nn.Linear(dim, dim)
+        self.fc2 = torch.nn.Linear(dim, dim)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = torch.nn.functional.relu(x)
+        x = self.fc2(x)
+        return x
+
+
+model = Model().to(device="cuda")
+x = torch.randn(4, dim, dim, device="cuda")
+
+# Transform for profiling with NVTX markers.
+# This transform adds NVTX markers to all the computation symbols in the execution trace.
+# It also marks the start and end of trace with cudaProfilerStart and cudaProfilerEnd to specify the capture range.
+from profile_transform import nvtx_profile_transform, nvtx_profiler_ex, profile_with_nvtx
+
+# Ideal UX
+# Problem - `transform_for_execution` is called after additional transforms.
+#           This leads to reordering of profiling operators when a FusionExecutor is present.
+# jmodel = thunder.jit(
+#     model,
+#     additional_transforms=[
+#         nvtx_profile_transform,
+#     ],
+#     executors=(nvtx_profiler_ex,) + thunder.get_default_executors(),
+# )
+# o = jmodel(x)
+
+jmodel = thunder.jit(model)
+jmodel(x)
+# Hacky but works (with FusionExecutors).
+# `profile_with_nvtx` grabs the execution trace
+# and inserts NVTX marker symbols to the trace and returns
+# a python callable with this new trace.
+# NOTE: # Model should be called atleast once so that we can grab execution trace.
+profiling_model = profile_with_nvtx(jmodel)
+profiling_model(x)

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -1,6 +1,6 @@
 import enum
 import sys
-from typing import Any
+from typing import Any, List
 from collections.abc import Callable
 from collections.abc import Hashable
 from types import ModuleType
@@ -211,6 +211,7 @@ class OperatorExecutor(Executor):
         bind_postprocess: None | Callable = None,
         replaces: None | Callable = None,
         python_printer: Callable = default_python_printer,
+        tags: None | list[Any] = None,
     ) -> Symbol:
         assert (like is None) ^ (meta is None), "Expected one and only one of 'like' and 'meta' to be specified"
         assert (module is not None) + (
@@ -236,6 +237,7 @@ class OperatorExecutor(Executor):
             executor=self,
             _bind_postprocess=_bind_postprocess,
             python_printer=python_printer,
+            tags=tags,
         )
         self.opmap[name] = sym
 


### PR DESCRIPTION
This transform adds NVTX markers to all the computation symbols in the execution trace.
It also marks the start and end of trace with cudaProfilerStart and cudaProfilerEnd to specify the capture range.

---------
#### UX
```python
# Current UX
jmodel = thunder.jit(model)
jmodel(x)
# Hacky but works (with FusionExecutors).
# `profile_with_nvtx` grabs the execution trace
# and inserts NVTX marker symbols to the trace and returns
# a python callable with this new trace.
# NOTE: # Model should be called atleast once so that we can grab execution trace.
profiling_model = profile_with_nvtx(jmodel)
profiling_model(x)

```

```python
# Ideal UX
# Problem - `transform_for_execution` is called after additional transforms.
#           This leads to reordering of profiling operators when a FusionExecutor is present.
#           One workaround could be that these symbols return some value which is consumed by the symbol they 
#           mark to create a dependence.
jmodel = thunder.jit(
    model,
    additional_transforms=[
        nvtx_profile_transform,
    ],
    executors=(nvtx_profiler_ex,) + thunder.get_default_executors(),
)
o = jmodel(x)
```

NOTE: Also it is helpful to print the trace so that `nsys` captures it in the report. This way the trace is easily available while checking the report in Nsight GUI.

------

Original Trace:
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
import torch.nn.functional
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast()
def augmented_forward_fn(*args):
  # args: "Collection" 
  t0, t1, t2, t3, t4, = args
  del args
  t5 = torch.nn.functional.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
    # t5 = ltorch.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
      # t5 = prims.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
  [t6, t7] = nvFusion0(t5)
    # t6 = prims.gt(t5, 0.0)  # t6: "cuda:0 b8[4, 4096, 4096]"
    # t7 = prims.where(t6, t5, 0.0)  # t7: "cuda:0 f32[4, 4096, 4096]"
  del t5
  t8 = torch.nn.functional.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
    # t8 = ltorch.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
      # t8 = prims.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
  return {'output': t8, 'flat_args': [t0, t1, t2, t3, t4], 'flat_output': (t8,)}, ((t0, t4, t6, t7), ())
```

Transformed Trace:
```python
# Constructed by Profile Transform (took 0 milliseconds)
import torch
import torch.nn.functional
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast()
def augmented_forward_fn(*args):
  cuda_profiler_start()
  # args: "Collection" 
  t0, t1, t2, t3, t4, = args
  del args
  nvtx_range_push('[\'t5 = torch.nn.functional.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"\']')
  t5 = torch.nn.functional.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
    # t5 = ltorch.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
      # t5 = prims.linear(t0, t3, t1)  # t5: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  nvtx_range_push("['[t6, t7] = nvFusion0(t5)']")
  [t6, t7] = nvFusion0(t5)
    # t6 = prims.gt(t5, 0.0)  # t6: "cuda:0 b8[4, 4096, 4096]"
    # t7 = prims.where(t6, t5, 0.0)  # t7: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  del t5
  nvtx_range_push('[\'t8 = torch.nn.functional.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"\']')
  t8 = torch.nn.functional.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
    # t8 = ltorch.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
      # t8 = prims.linear(t7, t4, t2)  # t8: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  cuda_profiler_stop()
  return {'output': t8, 'flat_args': [t0, t1, t2, t3, t4], 'flat_output': (t8,)}, ((t0, t4, t6, t7), ())
```
-------

#### Example

Profiling command: 
```bash
nsys profile --capture-range cudaProfilerApi python scratchpad/test_profiler.py
```

Example Visualization in Nsight.
![image](https://github.com/kshitij12345/lightning-thunder/assets/19503980/202e3f35-bfa6-4ed2-a170-9060e56fc5ec)
